### PR TITLE
Async path not working properly for transition to disk based files

### DIFF
--- a/src/FASTERCache/CacheBase.cs
+++ b/src/FASTERCache/CacheBase.cs
@@ -97,6 +97,7 @@ internal abstract class CacheBase<TInput, TOutput, TContext, TFunctions> : Cache
             ref CompletedOutput<SpanByte, SpanByte, TInput, TOutput, TContext> current = ref outputs.Current;
             status = current.Status;
             output = current.Output;
+            count++;
         }
         if (count != 1) Throw();
 

--- a/test/FASTERCacheTests/FunctionalTests.cs
+++ b/test/FASTERCacheTests/FunctionalTests.cs
@@ -256,7 +256,7 @@ public class FunctionalTests(FunctionalTests.CacheInstance fixture) : IClassFixt
 
         foreach (var trashKey in Enumerable.Reverse(trashKeys))
         {
-            var trash = await Cache.GetAsync(trashKey);
+            var trash = await Cache.GetAsync(trashKey); // for -2 the 8th one fails, which is memorysize/2, which is the size after which faster pushes to disk
             Assert.NotNull(trash);
         }
 


### PR DESCRIPTION
I tried to add proper tests for the async path, by reducing the actual log sitze. The page size is now 4096 byte, the memory size is 16kb, the disk segment size is 32kb.
The test writes less than pagesize data (multiple times) into the cache and tries to read them again. As soon as the cache hits the async path (actually writing data to disk) the test fails, you can see that the file is created (it's not created before that) and you can put in a breakpoint in ```AsyncTransitionGet``.

The test reads the keys in reverse, so the last 8 keys work for a size of 1kb, which is exactly half of the memory size, after which faster pushes the data to disk.

I found one bug (you never incremented the count for your CompleteSinglePending), but that's it.

I couldn't find the part why it fails, might take another look tomorrow.