### PR TITLE
Use Garnet's storage layer as in-process library, instead of FASTER

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -15,8 +15,8 @@
     <PackageVersion Include="xunit.runner.visualstudio" Version="2.5.7" />
     <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="8.0.0" />
     <PackageVersion Include="Nerdbank.GitVersioning" Version="3.6.133" />
-    <PackageVersion Include="Microsoft.FASTER.Core" Version="2.6.3" />
-    <PackageVersion Include="FusionRocks" Version="0.1.0" />
+    <PackageVersion Include="Microsoft.Garnet" Version="1.0.2" />
+	<PackageVersion Include="FusionRocks" Version="0.1.0" />
     <PackageVersion Include="Microsoft.CodeAnalysis.PublicApiAnalyzers" Version="3.3.4" />
   </ItemGroup>
 </Project>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -15,8 +15,8 @@
     <PackageVersion Include="xunit.runner.visualstudio" Version="2.5.7" />
     <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="8.0.0" />
     <PackageVersion Include="Nerdbank.GitVersioning" Version="3.6.133" />
-    <PackageVersion Include="Microsoft.Garnet" Version="1.0.2" />
-	<PackageVersion Include="FusionRocks" Version="0.1.0" />
+    <PackageVersion Include="Microsoft.Garnet" Version="1.0.3" />
+    <PackageVersion Include="FusionRocks" Version="0.1.0" />
     <PackageVersion Include="Microsoft.CodeAnalysis.PublicApiAnalyzers" Version="3.3.4" />
   </ItemGroup>
 </Project>

--- a/nuget.config
+++ b/nuget.config
@@ -4,6 +4,5 @@
     <!--To inherit the global NuGet package sources remove the <clear/> line below -->
     <clear />
     <add key="nuget" value="https://api.nuget.org/v3/index.json" />
-    <add key="local" value="c:\Code\NuGet" />
   </packageSources>
 </configuration>

--- a/src/FASTERCache.AspNetCore/OutputCacheStore.cs
+++ b/src/FASTERCache.AspNetCore/OutputCacheStore.cs
@@ -1,4 +1,4 @@
-﻿using FASTER.core;
+﻿using Tsavorite.core;
 using Microsoft.AspNetCore.OutputCaching;
 using System;
 using System.Threading;

--- a/src/FASTERCache/CacheBase.cs
+++ b/src/FASTERCache/CacheBase.cs
@@ -1,4 +1,4 @@
-﻿using FASTER.core;
+﻿using Tsavorite.core;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Internal;
 using System;

--- a/src/FASTERCache/CacheFunctionsBase.cs
+++ b/src/FASTERCache/CacheFunctionsBase.cs
@@ -1,5 +1,5 @@
-﻿using FASTER.core;
-using System;
+﻿using System;
+using Tsavorite.core;
 
 namespace FASTERCache;
 
@@ -8,40 +8,59 @@ namespace FASTERCache;
 /// </summary>
 internal class CacheFunctionsBase<TInput, TOutput, TContext> : FunctionsBase<SpanByte, SpanByte, TInput, TOutput, TContext>
 {
-    protected static bool Copy(ref SpanByte src, ref SpanByte dst)
+    /// <summary>
+    /// Utility function for SpanByte copying, Upsert version.
+    /// </summary>
+    protected static bool DoSafeCopy(ref SpanByte src, ref SpanByte dst, ref UpsertInfo upsertInfo, ref RecordInfo recordInfo)
     {
-        if (dst.Length < src.Length)
-        {
-            return false; // request more space
-        }
-        else if (dst.Length > src.Length)
-        {
-            dst.ShrinkSerializedLength(src.Length);
-        }
-        src.CopyTo(ref dst);
-        return true;
+        // First get the full record length and clear it from the extra value space (if there is any). 
+        // This ensures all bytes after the used value space are 0, which retains log-scan correctness.
+
+        // For non-in-place operations, the new record may have been revivified, so standard copying procedure must be done;
+        // For SpanByte we don't implement DisposeForRevivification, so any previous value is still there, and thus we must
+        // zero unused value space to ensure log-scan correctness, just like in in-place updates.
+
+        // IMPORTANT: usedValueLength and fullValueLength use .TotalSize, not .Length, to account for the leading "Length" int.
+        upsertInfo.ClearExtraValueLength(ref recordInfo, ref dst, dst.TotalSize);
+
+        // We want to set the used and extra lengths and Filler whether we succeed (to the new length) or fail (to the original length).
+        var result = src.TrySafeCopyTo(ref dst, upsertInfo.FullValueLength);
+        upsertInfo.SetUsedValueLength(ref recordInfo, ref dst, dst.TotalSize);
+        return result;
     }
 
-    public virtual bool Write(ref TInput input, ref SpanByte src, ref SpanByte dst, ref UpsertInfo upsertInfo)
-        => Copy(ref src, ref dst);
+    /// <summary>
+    /// Utility function for SpanByte copying, RMW version.
+    /// </summary>
+    public static bool DoSafeCopy(ref SpanByte src, ref SpanByte dst, ref RMWInfo rmwInfo, ref RecordInfo recordInfo)
+    {
+        // See comments in upsertInfo overload of this function.
+        rmwInfo.ClearExtraValueLength(ref recordInfo, ref dst, dst.TotalSize);
+        var result = src.TrySafeCopyTo(ref dst, rmwInfo.FullValueLength);
+        rmwInfo.SetUsedValueLength(ref recordInfo, ref dst, dst.TotalSize);
+        return result;
+    }
 
-    public override bool ConcurrentWriter(ref SpanByte key, ref TInput input, ref SpanByte src, ref SpanByte dst, ref TOutput output, ref UpsertInfo upsertInfo)
-        => Write(ref input, ref src, ref dst, ref upsertInfo);
-    public override bool SingleWriter(ref SpanByte key, ref TInput input, ref SpanByte src, ref SpanByte dst, ref TOutput output, ref UpsertInfo upsertInfo, WriteReason reason)
-        => Write(ref input, ref src, ref dst, ref upsertInfo);
+    public virtual bool Write(ref TInput input, ref SpanByte src, ref SpanByte dst, ref UpsertInfo upsertInfo, ref RecordInfo recordInfo)
+        => DoSafeCopy(ref src, ref dst, ref upsertInfo, ref recordInfo);
 
-    public override bool InitialUpdater(ref SpanByte key, ref TInput input, ref SpanByte value, ref TOutput output, ref RMWInfo rmwInfo)
+    public override bool ConcurrentWriter(ref SpanByte key, ref TInput input, ref SpanByte src, ref SpanByte dst, ref TOutput output, ref UpsertInfo upsertInfo, ref RecordInfo recordInfo)
+        => Write(ref input, ref src, ref dst, ref upsertInfo, ref recordInfo);
+    public override bool SingleWriter(ref SpanByte key, ref TInput input, ref SpanByte src, ref SpanByte dst, ref TOutput output, ref UpsertInfo upsertInfo, WriteReason reason, ref RecordInfo recordInfo)
+        => Write(ref input, ref src, ref dst, ref upsertInfo, ref recordInfo);
+
+    public override bool InitialUpdater(ref SpanByte key, ref TInput input, ref SpanByte value, ref TOutput output, ref RMWInfo rmwInfo, ref RecordInfo recordInfo)
     {
         // return base.InitialUpdater(ref key, ref input, ref value, ref output, ref rmwInfo);
         throw new NotSupportedException();
     }
-    public override bool CopyUpdater(ref SpanByte key, ref TInput input, ref SpanByte oldValue, ref SpanByte newValue, ref TOutput output, ref RMWInfo rmwInfo)
-        => Copy(ref oldValue, ref newValue);
-    public override bool InPlaceUpdater(ref SpanByte key, ref TInput input, ref SpanByte value, ref TOutput output, ref RMWInfo rmwInfo)
+    public override bool CopyUpdater(ref SpanByte key, ref TInput input, ref SpanByte oldValue, ref SpanByte newValue, ref TOutput output, ref RMWInfo rmwInfo, ref RecordInfo recordInfo)
+        => DoSafeCopy(ref oldValue, ref newValue, ref rmwInfo, ref recordInfo);
+    public override bool InPlaceUpdater(ref SpanByte key, ref TInput input, ref SpanByte value, ref TOutput output, ref RMWInfo rmwInfo, ref RecordInfo recordInfo)
     {
         rmwInfo.Action = RMWAction.CancelOperation;
         return false;
     }
-    public override bool ConcurrentDeleter(ref SpanByte key, ref SpanByte value, ref DeleteInfo deleteInfo) => true;
-    public override bool SingleDeleter(ref SpanByte key, ref SpanByte value, ref DeleteInfo deleteInfo) => true;
+    public override bool ConcurrentDeleter(ref SpanByte key, ref SpanByte value, ref DeleteInfo deleteInfo, ref RecordInfo recordInfo) => true;
+    public override bool SingleDeleter(ref SpanByte key, ref SpanByte value, ref DeleteInfo deleteInfo, ref RecordInfo recordInfo) => true;
 }

--- a/src/FASTERCache/CacheFunctionsBase.cs
+++ b/src/FASTERCache/CacheFunctionsBase.cs
@@ -6,61 +6,14 @@ namespace FASTERCache;
 /// <summary>
 /// Provides basic SpanByte-compatible function implementation
 /// </summary>
-internal class CacheFunctionsBase<TInput, TOutput, TContext> : FunctionsBase<SpanByte, SpanByte, TInput, TOutput, TContext>
+internal class CacheFunctionsBase<TInput, TOutput, TContext> : SpanByteFunctions<TInput, TOutput, TContext>
 {
-    /// <summary>
-    /// Utility function for SpanByte copying, Upsert version.
-    /// </summary>
-    protected static bool DoSafeCopy(ref SpanByte src, ref SpanByte dst, ref UpsertInfo upsertInfo, ref RecordInfo recordInfo)
-    {
-        // First get the full record length and clear it from the extra value space (if there is any). 
-        // This ensures all bytes after the used value space are 0, which retains log-scan correctness.
-
-        // For non-in-place operations, the new record may have been revivified, so standard copying procedure must be done;
-        // For SpanByte we don't implement DisposeForRevivification, so any previous value is still there, and thus we must
-        // zero unused value space to ensure log-scan correctness, just like in in-place updates.
-
-        // IMPORTANT: usedValueLength and fullValueLength use .TotalSize, not .Length, to account for the leading "Length" int.
-        upsertInfo.ClearExtraValueLength(ref recordInfo, ref dst, dst.TotalSize);
-
-        // We want to set the used and extra lengths and Filler whether we succeed (to the new length) or fail (to the original length).
-        var result = src.TrySafeCopyTo(ref dst, upsertInfo.FullValueLength);
-        upsertInfo.SetUsedValueLength(ref recordInfo, ref dst, dst.TotalSize);
-        return result;
-    }
-
-    /// <summary>
-    /// Utility function for SpanByte copying, RMW version.
-    /// </summary>
-    public static bool DoSafeCopy(ref SpanByte src, ref SpanByte dst, ref RMWInfo rmwInfo, ref RecordInfo recordInfo)
-    {
-        // See comments in upsertInfo overload of this function.
-        rmwInfo.ClearExtraValueLength(ref recordInfo, ref dst, dst.TotalSize);
-        var result = src.TrySafeCopyTo(ref dst, rmwInfo.FullValueLength);
-        rmwInfo.SetUsedValueLength(ref recordInfo, ref dst, dst.TotalSize);
-        return result;
-    }
-
-    public virtual bool Write(ref TInput input, ref SpanByte src, ref SpanByte dst, ref UpsertInfo upsertInfo, ref RecordInfo recordInfo)
-        => DoSafeCopy(ref src, ref dst, ref upsertInfo, ref recordInfo);
-
-    public override bool ConcurrentWriter(ref SpanByte key, ref TInput input, ref SpanByte src, ref SpanByte dst, ref TOutput output, ref UpsertInfo upsertInfo, ref RecordInfo recordInfo)
-        => Write(ref input, ref src, ref dst, ref upsertInfo, ref recordInfo);
-    public override bool SingleWriter(ref SpanByte key, ref TInput input, ref SpanByte src, ref SpanByte dst, ref TOutput output, ref UpsertInfo upsertInfo, WriteReason reason, ref RecordInfo recordInfo)
-        => Write(ref input, ref src, ref dst, ref upsertInfo, ref recordInfo);
-
     public override bool InitialUpdater(ref SpanByte key, ref TInput input, ref SpanByte value, ref TOutput output, ref RMWInfo rmwInfo, ref RecordInfo recordInfo)
-    {
-        // return base.InitialUpdater(ref key, ref input, ref value, ref output, ref rmwInfo);
-        throw new NotSupportedException();
-    }
+        => throw new NotSupportedException();
+
     public override bool CopyUpdater(ref SpanByte key, ref TInput input, ref SpanByte oldValue, ref SpanByte newValue, ref TOutput output, ref RMWInfo rmwInfo, ref RecordInfo recordInfo)
-        => DoSafeCopy(ref oldValue, ref newValue, ref rmwInfo, ref recordInfo);
+        => throw new NotSupportedException();
+
     public override bool InPlaceUpdater(ref SpanByte key, ref TInput input, ref SpanByte value, ref TOutput output, ref RMWInfo rmwInfo, ref RecordInfo recordInfo)
-    {
-        rmwInfo.Action = RMWAction.CancelOperation;
-        return false;
-    }
-    public override bool ConcurrentDeleter(ref SpanByte key, ref SpanByte value, ref DeleteInfo deleteInfo, ref RecordInfo recordInfo) => true;
-    public override bool SingleDeleter(ref SpanByte key, ref SpanByte value, ref DeleteInfo deleteInfo, ref RecordInfo recordInfo) => true;
+        => throw new NotSupportedException();
 }

--- a/src/FASTERCache/CacheService.cs
+++ b/src/FASTERCache/CacheService.cs
@@ -1,4 +1,4 @@
-﻿using FASTER.core;
+﻿using Tsavorite.core;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using System;
@@ -13,7 +13,7 @@ namespace FASTERCache;
 /// </summary>
 internal sealed class CacheService
 {
-    private readonly FasterKV<SpanByte, SpanByte> _cache;
+    private readonly TsavoriteKV<SpanByte, SpanByte> _cache;
 
     public CacheService(IOptions<FASTERCacheOptions> options, ILogger<CacheService> logger)
         : this(options.Value, logger) { }
@@ -67,6 +67,6 @@ internal sealed class CacheService
 
     public ClientSession<SpanByte, SpanByte, Input, Output, Context, Functions> CreateSession<Input, Output, Context, Functions>(Functions functions)
         where Functions : IFunctions<SpanByte, SpanByte, Input, Output, Context>
-        => _cache.For(functions).NewSession<Functions>();
+        => _cache.NewSession<Input, Output, Context, Functions>(functions);
 
 }

--- a/src/FASTERCache/DistributedCache.DebugCounters.cs
+++ b/src/FASTERCache/DistributedCache.DebugCounters.cs
@@ -1,4 +1,4 @@
-﻿using FASTER.core;
+﻿using Tsavorite.core;
 using System;
 using System.Runtime.InteropServices;
 using System.Threading;

--- a/src/FASTERCache/DistributedCache.Functions.cs
+++ b/src/FASTERCache/DistributedCache.Functions.cs
@@ -59,9 +59,6 @@ partial class DistributedCache
         public override bool ConcurrentReader(ref SpanByte key, ref TInput input, ref SpanByte value, ref TOutput dst, ref ReadInfo readInfo, ref RecordInfo recordInfo)
             => SingleReader(ref key, ref input, ref value, ref dst, ref readInfo);
 
-        public override bool Write(ref TInput input, ref SpanByte src, ref SpanByte dst, ref UpsertInfo upsertInfo, ref RecordInfo recordInfo)
-            => DoSafeCopy(ref src, ref dst, ref upsertInfo, ref recordInfo);
-
         public override bool InPlaceUpdater(ref SpanByte key, ref TInput input, ref SpanByte value, ref TOutput output, ref RMWInfo rmwInfo, ref RecordInfo recordInfo)
         {
             var span = value.AsSpan();

--- a/src/FASTERCache/DistributedCache.cs
+++ b/src/FASTERCache/DistributedCache.cs
@@ -1,4 +1,4 @@
-﻿using FASTER.core;
+﻿using Tsavorite.core;
 using Microsoft.Extensions.Caching.Distributed;
 using Microsoft.Extensions.Options;
 using System;
@@ -10,8 +10,8 @@ using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Threading;
 using System.Threading.Tasks;
-using BooleanSession = FASTER.core.ClientSession<FASTER.core.SpanByte, FASTER.core.SpanByte, FASTERCache.DistributedCache.BasicInputContext, bool, FASTER.core.Empty, FASTERCache.DistributedCache.BooleanFunctions>;
-using ByteArraySession = FASTER.core.ClientSession<FASTER.core.SpanByte, FASTER.core.SpanByte, FASTERCache.DistributedCache.BasicInputContext, byte[], FASTER.core.Empty, FASTERCache.DistributedCache.ByteArrayFunctions>;
+using BooleanSession = Tsavorite.core.ClientSession<Tsavorite.core.SpanByte, Tsavorite.core.SpanByte, FASTERCache.DistributedCache.BasicInputContext, bool, Tsavorite.core.Empty, FASTERCache.DistributedCache.BooleanFunctions>;
+using ByteArraySession = Tsavorite.core.ClientSession<Tsavorite.core.SpanByte, Tsavorite.core.SpanByte, FASTERCache.DistributedCache.BasicInputContext, byte[], Tsavorite.core.Empty, FASTERCache.DistributedCache.ByteArrayFunctions>;
 
 namespace FASTERCache;
 
@@ -101,7 +101,7 @@ internal sealed partial class DistributedCache : CacheBase,
         try
         {
             var keySpan = WriteKey(key.Length < MAX_STACKALLOC ? stackalloc byte[MAX_STACKALLOC] : default, key, out var lease);
-            ValueTask<FasterKV<SpanByte, SpanByte>.RmwAsyncResult<TInput, TOutput, Empty>> pendingRmwResult;
+            ValueTask<TsavoriteKV<SpanByte, SpanByte>.RmwAsyncResult<TInput, TOutput, Empty>> pendingRmwResult;
             unsafe
             {
                 fixed (byte* keyPtr = keySpan)
@@ -144,7 +144,7 @@ internal sealed partial class DistributedCache : CacheBase,
         static async ValueTask<TOutput?> Awaited(DistributedCache @this,
             ClientSession<SpanByte, SpanByte, TInput, TOutput, Empty, TFunction> session,
             ConcurrentBag<ClientSession<SpanByte, SpanByte, TInput, TOutput, Empty, TFunction>> sessions,
-            ValueTask<FasterKV<SpanByte, SpanByte>.RmwAsyncResult<TInput, TOutput, Empty>> pendingRmwResult
+            ValueTask<TsavoriteKV<SpanByte, SpanByte>.RmwAsyncResult<TInput, TOutput, Empty>> pendingRmwResult
             )
         {
             try
@@ -186,7 +186,7 @@ internal sealed partial class DistributedCache : CacheBase,
         try
         {
             var keySpan = WriteKey(key.Length < MAX_STACKALLOC ? stackalloc byte[MAX_STACKALLOC] : default, key, out var lease);
-            ValueTask<FasterKV<SpanByte, SpanByte>.ReadAsyncResult<TInput, TOutput, Empty>> pendingReadResult;
+            ValueTask<TsavoriteKV<SpanByte, SpanByte>.ReadAsyncResult<TInput, TOutput, Empty>> pendingReadResult;
             unsafe
             {
                 fixed (byte* keyPtr = keySpan)
@@ -229,7 +229,7 @@ internal sealed partial class DistributedCache : CacheBase,
         static async ValueTask<TOutput?> Awaited(DistributedCache @this,
             ClientSession<SpanByte, SpanByte, TInput, TOutput, Empty, TFunction> session,
             ConcurrentBag<ClientSession<SpanByte, SpanByte, TInput, TOutput, Empty, TFunction>> sessions,
-            ValueTask<FasterKV<SpanByte, SpanByte>.ReadAsyncResult<TInput, TOutput, Empty>> pendingRmwResult
+            ValueTask<TsavoriteKV<SpanByte, SpanByte>.ReadAsyncResult<TInput, TOutput, Empty>> pendingRmwResult
             )
         {
             try
@@ -368,7 +368,7 @@ internal sealed partial class DistributedCache : CacheBase,
         try
         {
             var keySpan = WriteKey(key.Length < MAX_STACKALLOC ? stackalloc byte[MAX_STACKALLOC] : default, key, out var lease);
-            ValueTask<FasterKV<SpanByte, SpanByte>.DeleteAsyncResult<BasicInputContext, bool, Empty>> pendingDeleteResult;
+            ValueTask<TsavoriteKV<SpanByte, SpanByte>.DeleteAsyncResult<BasicInputContext, bool, Empty>> pendingDeleteResult;
             unsafe
             {
                 fixed (byte* keyPtr = keySpan)
@@ -405,7 +405,7 @@ internal sealed partial class DistributedCache : CacheBase,
 
         static async Task Awaited(DistributedCache @this,
             BooleanSession session,
-            ValueTask<FasterKV<SpanByte, SpanByte>.DeleteAsyncResult<BasicInputContext, bool, Empty>> pendingDeleteResult)
+            ValueTask<TsavoriteKV<SpanByte, SpanByte>.DeleteAsyncResult<BasicInputContext, bool, Empty>> pendingDeleteResult)
         {
             try
             {
@@ -515,7 +515,7 @@ internal sealed partial class DistributedCache : CacheBase,
         {
             var keySpan = WriteKey(key.Length < MAX_STACKALLOC ? stackalloc byte[MAX_STACKALLOC] : default, key, out var lease);
             var valueSpan = WriteValue(value.Length <= MAX_STACKALLOC - 12 ? stackalloc byte[MAX_STACKALLOC] : default, value, out var valueLease, options);
-            ValueTask<FasterKV<SpanByte, SpanByte>.UpsertAsyncResult<BasicInputContext, bool, Empty>> pendingUpsertResult;
+            ValueTask<TsavoriteKV<SpanByte, SpanByte>.UpsertAsyncResult<BasicInputContext, bool, Empty>> pendingUpsertResult;
             unsafe
             {
                 fixed (byte* keyPtr = keySpan)
@@ -556,7 +556,7 @@ internal sealed partial class DistributedCache : CacheBase,
 
         static async ValueTask Awaited(DistributedCache @this,
             BooleanSession session,
-            ValueTask<FasterKV<SpanByte, SpanByte>.UpsertAsyncResult<BasicInputContext, bool, Empty>> pendingUpsertResult
+            ValueTask<TsavoriteKV<SpanByte, SpanByte>.UpsertAsyncResult<BasicInputContext, bool, Empty>> pendingUpsertResult
             )
         {
             try

--- a/src/FASTERCache/FASTERCache.csproj
+++ b/src/FASTERCache/FASTERCache.csproj
@@ -12,7 +12,7 @@
         <PackageReference Include="Microsoft.Extensions.Caching.Abstractions" />
         <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" />
         <PackageReference Include="Microsoft.Extensions.Options" />
-        <PackageReference Include="Microsoft.FASTER.Core" />
+        <PackageReference Include="Microsoft.Garnet" />
         <PackageReference Include="Microsoft.CodeAnalysis.PublicApiAnalyzers" PrivateAssets="all" />
     </ItemGroup>
 </Project>

--- a/src/FASTERCache/FASTERCacheOptions.cs
+++ b/src/FASTERCache/FASTERCacheOptions.cs
@@ -1,4 +1,4 @@
-﻿using FASTER.core;
+﻿using Tsavorite.core;
 using Microsoft.Extensions.Options;
 using System.IO;
 

--- a/test/FASTERCacheTests/FunctionalTests.cs
+++ b/test/FASTERCacheTests/FunctionalTests.cs
@@ -1,5 +1,4 @@
-﻿using FASTER.core;
-using Microsoft.Extensions.Caching.Distributed;
+﻿using Microsoft.Extensions.Caching.Distributed;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Internal;
 using System;


### PR DESCRIPTION
This PR replaces the use of FASTER in this codebase with Garnet in-process (or more specifically Garnet's storage layer library codenamed Tsavorite). Tsavorite is just a fork of FASTER that forms the backend for Garnet. Tsavorite is very similar to FASTER but it is optimized for the cache-store use case, which includes a specialized SpanByteAllocator, the ability to reuse holes in memory, etc. We are also focusing our efforts on the Tsavorite codebase going forward.

As Tsavorite is used by Garnet, it will continue to be better optimized and evolved going forward. It would be easier to have a single codebase that we evolve over time, rather than backporting every update to FASTER.

You will see that the changes to your library are not very deep, in fact some code gets reduced in the process due to SpanByteFunctions<I, O, C> in the base.

**It might also be a good idea to rename and move this to be a part of Garnet codebase and NuGet so that people get access to IDistributedCache via that discovery mechanism, and we can make sure we don't make future changes that negatively affect this layer.**
